### PR TITLE
Revert "Use condor-rc repos instead of condor-daily repos"

### DIFF
--- a/etc/distrepos.conf
+++ b/etc/distrepos.conf
@@ -37,25 +37,25 @@ source_rpms_subdir = src/Packages
 # aarch64, etc. based on the "arches" attribute of a tag.
 
 [condor-23.x]
-rc_repo = 23.x/$${EL}/$${ARCH}/rc -> condor-rc
+daily_repo = 23.x/$${EL}/$${ARCH}/daily -> condor-daily
 update_repo = 23.x/$${EL}/$${ARCH}/update -> condor-update
 release_repo = 23.x/$${EL}/$${ARCH}/release -> condor-release
 
 
 [condor-23.0]
-rc_repo = 23.0/$${EL}/$${ARCH}/rc -> condor-rc
+daily_repo = 23.0/$${EL}/$${ARCH}/daily -> condor-daily
 update_repo = 23.0/$${EL}/$${ARCH}/update -> condor-update
 release_repo = 23.0/$${EL}/$${ARCH}/release -> condor-release
 
 
 [condor-24.x]
-rc_repo = 24.x/$${EL}/$${ARCH}/rc -> condor-rc
+daily_repo = 24.x/$${EL}/$${ARCH}/daily -> condor-daily
 update_repo = 24.x/$${EL}/$${ARCH}/update -> condor-update
 release_repo = 24.x/$${EL}/$${ARCH}/release -> condor-release
 
 
 [condor-24.0]
-rc_repo = 24.0/$${EL}/$${ARCH}/rc -> condor-rc
+daily_repo = 24.0/$${EL}/$${ARCH}/daily -> condor-daily
 update_repo = 24.0/$${EL}/$${ARCH}/update -> condor-update
 release_repo = 24.0/$${EL}/$${ARCH}/release -> condor-release
 
@@ -119,7 +119,7 @@ mirror_hosts =
 [tagset osg-23-main-$${EL}-development]
 dvers = el8 el9
 dest = osg/23-main/$${EL}/development
-condor_repos = ${condor-23.0:rc_repo}
+condor_repos = ${condor-23.0:daily_repo}
 
 [tagset osg-23-main-$${EL}-testing]
 dvers = el8 el9
@@ -141,7 +141,7 @@ condor_repos = ${condor-23.0:release_repo}
 [tagset osg-23-upcoming-$${EL}-development]
 dvers = el8 el9
 dest = osg/23-upcoming/$${EL}/development
-condor_repos = ${condor-23.x:rc_repo}
+condor_repos = ${condor-23.x:daily_repo}
 
 [tagset osg-23-upcoming-$${EL}-testing]
 dvers = el8 el9
@@ -185,7 +185,7 @@ dest = osg/23-internal/$${EL}/release
 [tagset osg-24-main-$${EL}-development]
 dvers = el8 el9
 dest = osg/24-main/$${EL}/development
-# condor_repos = ${condor-24.0:rc_repo}
+# condor_repos = ${condor-24.0:daily_repo}
 
 [tagset osg-24-main-$${EL}-testing]
 dvers = el8 el9
@@ -207,7 +207,7 @@ dest = osg/24-main/$${EL}/release
 [tagset osg-24-upcoming-$${EL}-development]
 dvers = el8 el9
 dest = osg/24-upcoming/$${EL}/development
-# condor_repos = ${condor-24.x:rc_repo}
+# condor_repos = ${condor-24.x:daily_repo}
 
 [tagset osg-24-upcoming-$${EL}-testing]
 dvers = el8 el9


### PR DESCRIPTION
Reverts osg-htc/osg-repo-scripts#88

RPMs in the condor-rc repos are signed with a different key than RPMs in osg-development so we can't use them.